### PR TITLE
Python script to automatically generate documents from ansible galaxy metadata

### DIFF
--- a/generate_role_docs.py
+++ b/generate_role_docs.py
@@ -1,0 +1,151 @@
+import os
+import yaml
+from pathlib import Path
+
+def collect_constant_var_files(role_path):
+    constant_var_files = []
+
+    constant_var_files += [f"{role_path}/vars/main.yml"]
+
+    return constant_var_files
+
+def collect_default_var_files(role_path):
+    default_var_files = []
+
+    # defaults
+    default_var_files += [
+        f"{role_path}/defaults/main.yml",
+        f"{role_path}/defaults/main/main.yml"
+    ]
+    return default_var_files
+
+def extract_vars_with_comments(file_path):
+    if not Path(file_path).exists():
+        return []
+
+    lines = Path(file_path).read_text().splitlines()
+    result = []
+    current_comment = None
+
+    for line in lines:
+        line = line.strip()
+        if line.startswith("#"):
+            current_comment = line.lstrip("#").strip()
+        elif ":" in line:
+            var, val = line.split(":", 1)
+            var = var.strip()
+            val = val.strip()
+            result.append({
+                "name": var,
+                "value": val,
+                "comment": current_comment
+            })
+            current_comment = None
+    return result
+
+def load_yaml(file_path):
+    if not Path(file_path).exists():
+        return {}
+    with open(file_path, 'r') as f:
+        return yaml.safe_load(f) or {}
+
+def generate_role_markdown(role_path):
+    meta = load_yaml(f"{role_path}/meta/main.yml").get("galaxy_info", {})
+    vars_ = load_yaml(f"{role_path}/vars/main.yml")
+    tasks = load_yaml(f"{role_path}/tasks/main.yml")
+
+    lines = []
+
+    # Title
+    lines.append(f"# Role: `{Path(role_path).name}`\n")
+
+    # Overview
+    lines.append("## 📖 Overview")
+    lines.append(meta.get("description", "No description provided."))
+
+    # Requirements
+    lines.append("\n## 📋 Requirements")
+    lines.append(f"- Minimum Ansible version: `{meta.get('min_ansible_version', 'N/A')}`")
+    platforms = meta.get("platforms", [])
+    for p in platforms:
+        versions = ', '.join(p.get("versions", []))
+        lines.append(f"- Supported on: `{p['name']}` ({versions})")
+
+    # Defaults
+    lines.append("\n## 🧮 Defaults")
+    default_var_files = collect_default_var_files(role_path)
+    all_default_vars = []
+
+    for vf in default_var_files:
+        all_default_vars.extend(extract_vars_with_comments(vf))
+
+    if all_default_vars:
+        for var in all_default_vars:
+            comment = f" — {var['comment']}" if var['comment'] else ""
+            lines.append(f"- `{var['name']}`: `{var['value']}`{comment}")
+    else:
+        lines.append("_No default variables found in defaults._")
+
+    # Constants
+    lines.append("\n## 🧮 Vars")
+    constant_var_files = collect_constant_var_files(role_path)
+    all_constant_vars = []
+
+    for vf in constant_var_files:
+        all_constant_vars.extend(extract_vars_with_comments(vf))
+
+    if all_constant_vars:
+        for var in all_constant_vars:
+            comment = f" — {var['comment']}" if var['comment'] else ""
+            lines.append(f"- `{var['name']}`: `{var['value']}`{comment}")
+    else:
+        lines.append("_No constant variables found in vars._")
+
+    # Tasks
+    lines.append("\n## 🛠 Tasks")
+    if tasks:
+        for task in tasks:
+            name = task.get("name", "Unnamed task")
+            lines.append(f"- {name}")
+    else:
+        lines.append("_No tasks defined._")
+
+    # Example
+    lines.append("\n## 🚀 Example Usage")
+    lines.append("```yaml\n- hosts: all\n  roles:\n    - role: " + Path(role_path).name + "\n```")
+
+    return '\n'.join(lines), meta.get("description", "No description provided.")
+
+def main():
+    roles_dir = Path("roles")
+    index_entries = []
+
+    for role_path in roles_dir.iterdir():
+        if not role_path.is_dir():
+            continue
+        meta_file = role_path / "meta/main.yml"
+        if not meta_file.exists():
+            continue
+
+        markdown, description = generate_role_markdown(role_path)
+        readme_path = role_path / "README.md"
+        readme_path.write_text(markdown)
+
+        index_entries.append({
+            "name": role_path.name,
+            "description": description
+        })
+
+    # Sort alphabetically by role name
+    index_entries.sort(key=lambda x: x["name"].lower())
+
+    # Write index
+    index_lines = ["# 📚 Role Index\n"]
+    for entry in index_entries:
+        index_lines.append(f"- [`{entry['name']}`]({entry['name']}/README.md): {entry['description']}")
+
+    index_path = roles_dir / "README.md"
+    index_path.write_text('\n'.join(index_lines))
+
+if __name__ == "__main__":
+    main()

--- a/inventory/ansible/inventory.ini
+++ b/inventory/ansible/inventory.ini
@@ -1,12 +1,10 @@
 [vms]
 ansible-0 vms_proxmox_node=pve-0
 ansible-1 vms_proxmox_node=pve-1
-ansible-2 vms_proxmox_node=pve-2
 
 [linux]
 ansible-0
 ansible-1
-ansible-2
 
 [terraform:children]
 vms

--- a/inventory/ansible/inventory.ini
+++ b/inventory/ansible/inventory.ini
@@ -1,16 +1,18 @@
-[ansible]
+[vms]
 ansible-0 vms_proxmox_node=pve-0
 ansible-1 vms_proxmox_node=pve-1
+ansible-2 vms_proxmox_node=pve-2
 
 [linux]
 ansible-0
 ansible-1
+ansible-2
 
 [terraform:children]
 vms
 
-[vms:children]
-ansible
+[ansible:children]
+vms
 
 [pgclient]
 ansible-1

--- a/roles/global/meta/main.yml
+++ b/roles/global/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: global
+  author: Francis Refol
+  description: Provides global defaults common to all roles. It also provides the IP definition of each host in the datacenter.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms:
+    - name: EL
+      versions:
+        - "7"
+        - "8"
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal

--- a/roles/global/vars/main.yml
+++ b/roles/global/vars/main.yml
@@ -36,6 +36,5 @@ global_ip_addresses:
   pxe-0: 192.168.2.254
   util-0: 192.168.0.56
 
-# noqa: var-naming[no-role-prefix]
 global_ip_address: "{{ global_ip_addresses[inventory_hostname] }}"
 global_pihole_api_host: "{{ global_ip_addresses['dns-0'] }}"

--- a/roles/nginx_setup/meta/main.yml
+++ b/roles/nginx_setup/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: nginx_setup
+  author: Francis Refol
+  description: Installs the nginx service.
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms:
+    - name: EL
+      versions:
+        - "7"
+        - "8"
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
+dependencies:
+  - role: common


### PR DESCRIPTION
This Python script walks the each roles folder and generates a README.md file in each roles folder containing information about the role that has been generated from the galaxy metadata file. It also updates a README.md containing the index to the generated role documentation. 